### PR TITLE
Corrected civicPhoto div empty issue

### DIFF
--- a/public/js/googleCivic.js
+++ b/public/js/googleCivic.js
@@ -4,6 +4,7 @@ $("#addressSubmit").on("click", function (event) {
   event.preventDefault();
   // Empty the googleCivic info div
   $(".civicInfo").empty();
+  $(".civicPhoto").empty();
 
   $("#civicDiv").toggleClass('d-none', false);
 


### PR DESCRIPTION
### Aligns with Issue #21 

### JavaScript
* Added `$(".civicPhoto").empty();` to onClick function to make sure previous search related photo is removed upon issuing a new search.